### PR TITLE
Fix upgrade path

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,8 +36,10 @@ Depends: adduser,
          ${shlibs:Depends}
 Recommends: libpam-cgfs
 Suggests: btrfs-tools, lvm2, lxc-templates, lxctl
-Replaces: lxc1 (<< 2.1.1-0ubuntu2~)
-Breaks: lxc1 (<< 2.1.1-0ubuntu2~)
+Replaces: lxc1 (<< 2.1.1-0ubuntu2~),
+          lxc-utils (<< 1:5.0.1-0ubuntu7)
+Breaks: lxc1 (<< 2.1.1-0ubuntu2~),
+        lxc-utils (<< 1:5.0.1-0ubuntu7)
 Description: Linux Containers userspace tools
  Containers are insulated areas inside a system, which have their own namespace
  for filesystem, network, PID, IPC, CPU and memory allocation and which can be

--- a/debian/control
+++ b/debian/control
@@ -67,8 +67,10 @@ Depends: liblxc1 (= ${binary:Version}),
          libseccomp-dev,
          libselinux1-dev,
          ${misc:Depends}
-Replaces: lxc-dev (<< 2.1.1-0ubuntu2~)
-Breaks: lxc-dev (<< 2.1.1-0ubuntu2~)
+Replaces: lxc-dev (<< 2.1.1-0ubuntu2~),
+          liblxc-dev (<< 1:5.0.1-0ubuntu7)
+Breaks: lxc-dev (<< 2.1.1-0ubuntu2~),
+        liblxc-dev (<< 1:5.0.1-0ubuntu7)
 Description: Linux Containers userspace tools (development)
  Containers are insulated areas inside a system, which have their own namespace
  for filesystem, network, PID, IPC, CPU and memory allocation and which can be


### PR DESCRIPTION
This is an attempt at fixing the upgrade path:

```
root@n:~# apt-get dist-upgrade -V
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following package was automatically installed and is no longer required:
   lxc-utils (1:5.0.3-0ubuntu1)
Use 'apt autoremove' to remove it.
The following packages will be upgraded:
   liblxc-common (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu1)
   liblxc1 (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu1)
   libpam-cgfs (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu1)
   lxc (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu1)
   lxc-utils (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu1)
5 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 4124 kB of archives.
After this operation, 350 kB disk space will be freed.
Do you want to continue? [Y/n] 
Get:1 https://ppa.launchpadcontent.net/mihalicyn/lxc-ppa-3/ubuntu noble/main amd64 libpam-cgfs amd64 1:5.0.3-0ubuntu1 [28.9 kB]
Get:2 https://ppa.launchpadcontent.net/mihalicyn/lxc-ppa-3/ubuntu noble/main amd64 lxc amd64 1:5.0.3-0ubuntu1 [2758 kB]
Get:3 https://ppa.launchpadcontent.net/mihalicyn/lxc-ppa-3/ubuntu noble/main amd64 liblxc1 amd64 1:5.0.3-0ubuntu1 [405 kB]
Get:4 https://ppa.launchpadcontent.net/mihalicyn/lxc-ppa-3/ubuntu noble/main amd64 liblxc-common amd64 1:5.0.3-0ubuntu1 [922 kB]
Get:5 https://ppa.launchpadcontent.net/mihalicyn/lxc-ppa-3/ubuntu noble/main amd64 lxc-utils all 1:5.0.3-0ubuntu1 [10.2 kB]                                                                                                                                                        
Fetched 4124 kB in 7s (628 kB/s)                                                                                                                                                                                                                                                   
(Reading database ... 65911 files and directories currently installed.)
Preparing to unpack .../libpam-cgfs_1%3a5.0.3-0ubuntu1_amd64.deb ...
Unpacking libpam-cgfs (1:5.0.3-0ubuntu1) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../lxc_1%3a5.0.3-0ubuntu1_amd64.deb ...
Unpacking lxc (1:5.0.3-0ubuntu1) over (1:5.0.1-0ubuntu7) ...
dpkg: error processing archive /var/cache/apt/archives/lxc_1%3a5.0.3-0ubuntu1_amd64.deb (--unpack):
 trying to overwrite '/etc/default/lxc', which is also in package lxc-utils 1:5.0.1-0ubuntu7
dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
Preparing to unpack .../liblxc1_1%3a5.0.3-0ubuntu1_amd64.deb ...
Unpacking liblxc1 (1:5.0.3-0ubuntu1) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../liblxc-common_1%3a5.0.3-0ubuntu1_amd64.deb ...
Unpacking liblxc-common (1:5.0.3-0ubuntu1) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../lxc-utils_1%3a5.0.3-0ubuntu1_all.deb ...
Unpacking lxc-utils (1:5.0.3-0ubuntu1) over (1:5.0.1-0ubuntu7) ...
dpkg: warning: unable to delete old directory '/etc/lxc': Directory not empty
dpkg: warning: unable to delete old directory '/etc/dnsmasq.d-available': Directory not empty
Errors were encountered while processing:
 /var/cache/apt/archives/lxc_1%3a5.0.3-0ubuntu1_amd64.deb
needrestart is being skipped since dpkg has failed
E: Sub-process /usr/bin/dpkg returned an error code (1)
```