### PR TITLE
d/control: fix replaces/breaks version tags

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,9 +37,9 @@ Depends: adduser,
 Recommends: libpam-cgfs
 Suggests: btrfs-tools, lvm2, lxc-templates, lxctl
 Replaces: lxc1 (<< 2.1.1-0ubuntu2~),
-          lxc-utils (<< 1:5.0.1-0ubuntu7)
+          lxc-utils (<< 1:5.0.3-0ubuntu1~)
 Breaks: lxc1 (<< 2.1.1-0ubuntu2~),
-        lxc-utils (<< 1:5.0.1-0ubuntu7)
+        lxc-utils (<< 1:5.0.3-0ubuntu1~)
 Description: Linux Containers userspace tools
  Containers are insulated areas inside a system, which have their own namespace
  for filesystem, network, PID, IPC, CPU and memory allocation and which can be
@@ -68,9 +68,9 @@ Depends: liblxc1 (= ${binary:Version}),
          libselinux1-dev,
          ${misc:Depends}
 Replaces: lxc-dev (<< 2.1.1-0ubuntu2~),
-          liblxc-dev (<< 1:5.0.1-0ubuntu7)
+          liblxc-dev (<< 1:5.0.3-0ubuntu1~)
 Breaks: lxc-dev (<< 2.1.1-0ubuntu2~),
-        liblxc-dev (<< 1:5.0.1-0ubuntu7)
+        liblxc-dev (<< 1:5.0.3-0ubuntu1~)
 Description: Linux Containers userspace tools (development)
  Containers are insulated areas inside a system, which have their own namespace
  for filesystem, network, PID, IPC, CPU and memory allocation and which can be


### PR DESCRIPTION
This fixes the upgrade path for real:

```
root@n:~#  apt-get dist-upgrade -V
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages were automatically installed and are no longer required:
   liblxc-dev (1:5.0.3-0ubuntu2)
   lxc-utils (1:5.0.3-0ubuntu2)
Use 'apt autoremove' to remove them.
The following packages will be upgraded:
   liblxc-common (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   liblxc-dev (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   liblxc1 (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   libpam-cgfs (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   libpam-modules (1.5.2-6ubuntu1 => 1.5.2-9.1ubuntu1)
   libpam-modules-bin (1.5.2-6ubuntu1 => 1.5.2-9.1ubuntu1)
   libpam-runtime (1.5.2-6ubuntu1 => 1.5.2-9.1ubuntu1)
   libpam0g (1.5.2-6ubuntu1 => 1.5.2-9.1ubuntu1)
   lxc (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   lxc-dev (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
   lxc-utils (1:5.0.1-0ubuntu7 => 1:5.0.3-0ubuntu2)
11 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 5079 kB of archives.
After this operation, 321 kB disk space will be freed.
Do you want to continue? [Y/n] 
Get:1 http://archive.ubuntu.com/ubuntu noble/main amd64 libpam0g amd64 1.5.2-9.1ubuntu1 [65.1 kB]
Get:2 http://archive.ubuntu.com/ubuntu noble/main amd64 libpam-modules-bin amd64 1.5.2-9.1ubuntu1 [47.6 kB]
Get:3 http://archive.ubuntu.com/ubuntu noble/main amd64 libpam-modules amd64 1.5.2-9.1ubuntu1 [284 kB]
Get:4 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 libpam-cgfs amd64 1:5.0.3-0ubuntu2 [28.9 kB]
Get:5 http://archive.ubuntu.com/ubuntu noble/main amd64 libpam-runtime all 1.5.2-9.1ubuntu1 [41.5 kB]
Get:6 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 liblxc-dev all 1:5.0.3-0ubuntu2 [10.2 kB]
Get:7 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 liblxc1 amd64 1:5.0.3-0ubuntu2 [405 kB]
Get:8 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 liblxc-common amd64 1:5.0.3-0ubuntu2 [922 kB]
Get:9 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 lxc-utils all 1:5.0.3-0ubuntu2 [10.2 kB]
Get:10 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 lxc amd64 1:5.0.3-0ubuntu2 [2760 kB]
Get:11 https://ppa.launchpadcontent.net/sdeziel/ppa/ubuntu noble/main amd64 lxc-dev amd64 1:5.0.3-0ubuntu2 [504 kB]
Fetched 5079 kB in 2s (2374 kB/s)
Preconfiguring packages ...
(Reading database ... 70888 files and directories currently installed.)
Preparing to unpack .../libpam0g_1.5.2-9.1ubuntu1_amd64.deb ...
Unpacking libpam0g:amd64 (1.5.2-9.1ubuntu1) over (1.5.2-6ubuntu1) ...
Setting up libpam0g:amd64 (1.5.2-9.1ubuntu1) ...
(Reading database ... 70887 files and directories currently installed.)
Preparing to unpack .../libpam-modules-bin_1.5.2-9.1ubuntu1_amd64.deb ...
Unpacking libpam-modules-bin (1.5.2-9.1ubuntu1) over (1.5.2-6ubuntu1) ...
Setting up libpam-modules-bin (1.5.2-9.1ubuntu1) ...
pam_namespace.service is a disabled or a static unit not running, not starting it.
(Reading database ... 70886 files and directories currently installed.)
Preparing to unpack .../libpam-modules_1.5.2-9.1ubuntu1_amd64.deb ...
Unpacking libpam-modules:amd64 (1.5.2-9.1ubuntu1) over (1.5.2-6ubuntu1) ...
Setting up libpam-modules:amd64 (1.5.2-9.1ubuntu1) ...
(Reading database ... 70885 files and directories currently installed.)
Preparing to unpack .../libpam-runtime_1.5.2-9.1ubuntu1_all.deb ...
Unpacking libpam-runtime (1.5.2-9.1ubuntu1) over (1.5.2-6ubuntu1) ...
Setting up libpam-runtime (1.5.2-9.1ubuntu1) ...
(Reading database ... 70884 files and directories currently installed.)
Preparing to unpack .../0-libpam-cgfs_1%3a5.0.3-0ubuntu2_amd64.deb ...
Unpacking libpam-cgfs (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../1-liblxc-dev_1%3a5.0.3-0ubuntu2_all.deb ...
Unpacking liblxc-dev (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../2-liblxc1_1%3a5.0.3-0ubuntu2_amd64.deb ...
Unpacking liblxc1 (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../3-liblxc-common_1%3a5.0.3-0ubuntu2_amd64.deb ...
Unpacking liblxc-common (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../4-lxc-utils_1%3a5.0.3-0ubuntu2_all.deb ...
Unpacking lxc-utils (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
dpkg: warning: unable to delete old directory '/etc/lxc': Directory not empty
dpkg: warning: unable to delete old directory '/etc/dnsmasq.d-available': Directory not empty
Preparing to unpack .../5-lxc_1%3a5.0.3-0ubuntu2_amd64.deb ...
Unpacking lxc (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Preparing to unpack .../6-lxc-dev_1%3a5.0.3-0ubuntu2_amd64.deb ...
Unpacking lxc-dev (1:5.0.3-0ubuntu2) over (1:5.0.1-0ubuntu7) ...
Setting up libpam-cgfs (1:5.0.3-0ubuntu2) ...
Setting up liblxc1 (1:5.0.3-0ubuntu2) ...
Setting up lxc-dev (1:5.0.3-0ubuntu2) ...
Setting up liblxc-dev (1:5.0.3-0ubuntu2) ...
Setting up lxc (1:5.0.3-0ubuntu2) ...
Installing new version of config file /etc/default/lxc ...
Setting up lxc dnsmasq configuration.
Setting up liblxc-common (1:5.0.3-0ubuntu2) ...
Installing new version of config file /etc/apparmor.d/abstractions/lxc/start-container ...
Installing new version of config file /etc/apparmor.d/lxc/lxc-default-cgns ...
Setting up lxc-utils (1:5.0.3-0ubuntu2) ...
Processing triggers for libc-bin (2.38-3ubuntu1) ...
Processing triggers for man-db (2.11.2-3) ...
```

Once upgraded, the transitional packages are ready for removal:

```
root@n:~# apt-get autopurge
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages will be REMOVED:
  liblxc-dev* lxc-utils*
0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
After this operation, 36.9 kB disk space will be freed.
Do you want to continue? [Y/n] 
(Reading database ... 70884 files and directories currently installed.)
Removing liblxc-dev (1:5.0.3-0ubuntu2) ...
Removing lxc-utils (1:5.0.3-0ubuntu2) ...
(Reading database ... 70878 files and directories currently installed.)
Purging configuration files for lxc-utils (1:5.0.3-0ubuntu2) ...
```

And that still leaves the `lxc-*` tools available:

```
root@n:~# hash -r
root@n:~# lxc-<TAB>
lxc-attach         lxc-checkpoint     lxc-create         lxc-freeze         lxc-snapshot       lxc-unfreeze       lxc-wait
lxc-autostart      lxc-config         lxc-destroy        lxc-info           lxc-start          lxc-unshare        
lxc-cgroup         lxc-console        lxc-device         lxc-ls             lxc-stop           lxc-update-config  
lxc-checkconfig    lxc-copy           lxc-execute        lxc-monitor        lxc-top            lxc-usernsexec
```